### PR TITLE
pathlib PosixPath to Path for Windows compatibility

### DIFF
--- a/fstrider/fstrider.py
+++ b/fstrider/fstrider.py
@@ -203,12 +203,12 @@ class fstrider:
         def _list_enter(event):
             radio_list._handle_enter()
 
-            if type(self.list.current_value) is pathlib.PosixPath:
+            if type(self.list.current_value) is pathlib.Path:
                 self.history_append(self.list.current_value)
 
             selected_item = radio_list.current_value
 
-            if type(selected_item) is pathlib.PosixPath:
+            if type(selected_item) is pathlib.Path:
                 self.stride(selected_by_value=radio_list.current_value, file_msg={radio_list.current_value: 'Open with OS'})
                 open_in_os(radio_list.current_value)
             elif callable(selected_item):
@@ -218,7 +218,7 @@ class fstrider:
         def _list_right(event):
             radio_list._handle_enter()
             p = radio_list.current_value
-            if type(p) is pathlib.PosixPath:
+            if type(p) is pathlib.Path:
                 if p.is_dir():
                     self.stride(p)
                 else:
@@ -230,7 +230,7 @@ class fstrider:
         @radio_list.control.key_bindings.add("space")
         def _list_space(event):
             radio_list._handle_enter()
-            if type(self.list.current_value) is pathlib.PosixPath:
+            if type(self.list.current_value) is pathlib.Path:
                 self.show_actions_menu()
 
         @radio_list.control.key_bindings.add("c-j")


### PR DESCRIPTION
Hi! Thank you for the awesome xontrib! I gave it a star!

Please take a look at my PR that ...

Change PosixPath references to the more generic Path, so navigation and other functionality will work as expected in Windows. As set up currently, running fstrider in Windows, nothing happens after the PosixPath checks.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
